### PR TITLE
remove php version of coverage report output

### DIFF
--- a/bin/runtests-coverage
+++ b/bin/runtests-coverage
@@ -77,7 +77,7 @@ function runSuite($suite, $phpUnit, $arguments)
     $arguments = implode(' ', $arguments);
     $return = 0;
     $suite = escapeshellarg($suite);
-    passthru("TEST_SUITE=$suite $phpUnit --coverage-php $reportsDir/coverage.cov --coverage-clover $reportsDir/clover.xml --coverage-html $reportsDir/html $configuration $arguments", $return);
+    passthru("TEST_SUITE=$suite $phpUnit --coverage-clover $reportsDir/clover.xml --coverage-html $reportsDir/html $configuration $arguments", $return);
 
     return $return;
 }


### PR DESCRIPTION
we only need clover and html reports and the jenkins server is running out of memory for PHP for many test suites